### PR TITLE
Use fuzzy timestamps for submission cards

### DIFF
--- a/lib/features/subreddit/submission_tile.dart
+++ b/lib/features/subreddit/submission_tile.dart
@@ -10,6 +10,7 @@ import 'package:lurkur/app/widgets/pop_ups.dart';
 import 'package:lurkur/app/widgets/tags.dart';
 import 'package:lurkur/features/submission/video_tile.dart';
 import 'package:provider/provider.dart';
+import 'package:timeago/timeago.dart' as timeago;
 
 class SubmissionTile extends StatelessWidget {
   const SubmissionTile({
@@ -285,8 +286,7 @@ class _Context extends StatelessWidget {
               ),
             ),
           TextSpan(
-            text:
-                '${DateTime.now().difference(submission.createdDateTime).inHours} hours ago',
+            text: timeago.format(submission.createdDateTime, locale: 'en'),
             style: context.textTheme.bodyMedium?.copyWith(),
           ),
           TextSpan(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   flutter_secure_storage: ^8.0.0
   chewie: ^1.6.0+1
   video_player: ^2.7.0
+  timeago: ^3.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Description
Timestamp submission cards are currently displayed in hours which looks strange when using some sorting methods (specifically "top week/month/etc" now, but also likely with "new" when that's added.) This imports the `timeago` package to generate fuzzy timestamps for submission cards.

I figure that this will probably be wanted later on for attaching timestamps to comments as well.

### Testing:
Tested locally:

<img width="430" alt="image" src="https://github.com/Joseph-W-E/lurkur/assets/66858469/5aeb3499-94e8-41b5-bb72-d9fd500b4473">