### PR TITLE
Add auth functionality so you do not need to log in on each boot, Also add multidex support for android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -49,6 +49,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion flutter.minSdkVersion
+        multiDexEnabled true
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
@@ -69,4 +70,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.android.support:multidex:1.0.3'
 }

--- a/lib/app/blocs/router_cubit.dart
+++ b/lib/app/blocs/router_cubit.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:lurkur/features/sign_in_page.dart';
 import 'package:lurkur/features/subreddit_page.dart';
 
+import '../../features/loading_page.dart';
+
 /// Manages the routes available in the app.
 class RouterCubit extends Cubit<RouteState> {
   static const signIn = '/';
@@ -11,7 +13,7 @@ class RouterCubit extends Cubit<RouteState> {
 
   static const subredditQueryParameter = 'subreddit';
 
-  RouterCubit() : super(UnauthorizedRoutes());
+  RouterCubit() : super(UnknownAuthRoutes());
 
   void showUnauthorizedRoutes() {
     emit(UnauthorizedRoutes());
@@ -59,6 +61,20 @@ sealed class RouteState {
   ///
   /// Failing to do so will result in hard-to-trace navigation history issues.
   RouterConfig<Object> get routerConfig;
+}
+
+/// Provides the default app boot route
+class UnknownAuthRoutes extends RouteState {
+  @override
+  final RouterConfig<Object> routerConfig = GoRouter(
+    initialLocation: RouterCubit.signIn,
+    routes: [
+      GoRoute(
+        path: RouterCubit.signIn,
+        builder: (context, state) => LoadingPage(),
+      ),
+    ],
+  );
 }
 
 /// Provides routes available for those that haven't signed in yet.

--- a/lib/features/loading_page.dart
+++ b/lib/features/loading_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:lurkur/app/blocs/theme_cubit.dart';
+import 'package:lurkur/app/widgets/layout.dart';
+import 'package:provider/provider.dart';
+
+import '../app/blocs/auth_cubit.dart';
+import '../app/blocs/router_cubit.dart';
+
+
+class LoadingPage extends StatefulWidget {
+  @override
+  _LoadingPageState createState() => _LoadingPageState();
+}
+
+class _LoadingPageState extends State<LoadingPage> {
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Future<bool> _checkAuth(BuildContext context) async {
+    // Do a little delay to make the experience nicer.
+    final authCubit = context.read<AuthCubit>();
+    authCubit.checkExistingAuth();
+    return Future(() => true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Align(
+        alignment: const FractionalOffset(0.5, 0.45),
+        child: SeparatedColumn(
+          mainAxisSize: MainAxisSize.min,
+          space: ThemeCubit.medium2Padding,
+          children: [
+            FutureBuilder(future: _checkAuth(context), builder: (context, snapshot) {
+              return const Center(child: Text('Auth Complete'));
+            })
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings_popup.dart
+++ b/lib/features/settings_popup.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:lurkur/app/blocs/auth_cubit.dart';
 import 'package:lurkur/app/blocs/preference_cubit.dart';
 import 'package:lurkur/app/blocs/theme_cubit.dart';
 import 'package:lurkur/app/widgets/popups.dart';
@@ -40,10 +41,7 @@ class SettingsBody extends StatelessWidget {
         _HeaderTile(text: 'Session'),
         _HiddenSubreddits(),
         _ClearPreferences(),
-        ListTile(
-          leading: Icon(Icons.logout),
-          title: Text('Log out'),
-        ),
+        _LogOut(),
       ],
     );
   }
@@ -129,6 +127,18 @@ class _AutoPlayVideos extends StatelessWidget {
       },
       title: const Text('Auto play videos'),
       onTap: () => context.read<PreferenceCubit>().nextAutoPlayVideos(),
+    );
+  }
+}
+
+class _LogOut extends StatelessWidget {
+  const _LogOut();
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.logout),
+      title: const Text('Log Out'),
+      onTap: () => context.read<AuthCubit>().logout(),
     );
   }
 }


### PR DESCRIPTION
Additions:
- New Unknown auth state for cold app boot
- New route for unknown auth state
- Loading page that loads tokens from secure storage to determine auth state
- On login, store tokens to secure storage for reuse
- Add multidex support for android, was running into single dex max method size errors. 
- Wire up logout button in the settings to log you out.

I dont use dart or flutter, like ever, so feel free to roast this code. 